### PR TITLE
Enable the service by default on Debian

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,7 +11,23 @@
 # Copyright (C) 2013 Joshua Hoblitt
 #
 class sysstat::install {
-  package { $sysstat::params::sysstat_package:
-    ensure => present,
-  }
+
+ case $::osfamily {
+  'debian': {
+              package { $sysstat::params::sysstat_package:
+                        ensure => present,
+                      }
+
+              augeas { '/etc/default/sysstat':
+              context => '/files/etc/default/sysstat/',
+              changes => 'set ENABLED true',
+              require => Package['sysstat'],}
+            }
+  default:  
+              package { $sysstat::params::sysstat_package:
+              ensure => present, }
+            }
+
+                }
 }
+

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -11,23 +11,21 @@
 # Copyright (C) 2013 Joshua Hoblitt
 #
 class sysstat::install {
+  case $::osfamily {
+    'debian': {
+      package { $sysstat::params::sysstat_package:
+      ensure => present, }
 
- case $::osfamily {
-  'debian': {
-              package { $sysstat::params::sysstat_package:
-                        ensure => present,
-                      }
-
-              augeas { '/etc/default/sysstat':
-              context => '/files/etc/default/sysstat/',
-              changes => 'set ENABLED true',
-              require => Package['sysstat'],}
-            }
-  default:  
-              package { $sysstat::params::sysstat_package:
-              ensure => present, }
-            }
-
-                }
+      augeas { '/etc/default/sysstat':
+      context => '/files/etc/default/sysstat/',
+      changes => 'set ENABLED true',
+      require => Package['sysstat'],}
+  }
+  default: {
+    package { $sysstat::params::sysstat_package:
+    ensure => present, }
+     }
+   }
 }
+
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,13 +19,13 @@ class sysstat::install {
       augeas { '/etc/default/sysstat':
       context => '/files/etc/default/sysstat/',
       changes => 'set ENABLED true',
-      require => Package['sysstat'],}
+      require => Package[$sysstat::params::sysstat_package],}
   }
   default: {
     package { $sysstat::params::sysstat_package:
     ensure => present, }
-     }
-   }
+  }
+  }
 }
 
 


### PR DESCRIPTION
In order to run the sysstat at system start and enabling the collection of performance data you need to change the `ENABLED` parameter to `true` in `/etc/default/sysstat`

This can be simply done with augeas:  
`augeas { '/etc/default/sysstat':
    context => '/files/etc/default/sysstat/',
    changes => 'set ENABLED true',
    require => Package['sysstat'],
  }`
